### PR TITLE
Add simple error page for 404 and other errors

### DIFF
--- a/apps/whispering/src/routes/+error.svelte
+++ b/apps/whispering/src/routes/+error.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+<svelte:head>
+	<title>
+		{$page.status === 404 ? 'Page Not Found' : 'Error'} - Whispering
+	</title>
+</svelte:head>
+
+<main class="flex flex-1 flex-col items-center justify-center gap-6 p-8">
+	<div class="text-center space-y-6">
+		<h1 class="text-4xl font-bold text-foreground">
+			{#if $page.status === 404}
+				404 - Page Not Found
+			{:else}
+				Something Went Wrong
+			{/if}
+		</h1>
+
+		<p class="text-muted-foreground text-lg">
+			{#if $page.status === 404}
+				The page you're looking for doesn't exist.
+			{:else}
+				An unexpected error occurred.
+			{/if}
+		</p>
+
+		<div class="pt-4">
+			<a 
+				href="/"
+				class="inline-flex items-center justify-center rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 transition-colors"
+			>
+				Go Home
+			</a>
+		</div>
+	</div>
+</main>

--- a/apps/whispering/src/routes/+error.svelte
+++ b/apps/whispering/src/routes/+error.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 </script>
 
 <svelte:head>
 	<title>
-		{$page.status === 404 ? 'Page Not Found' : 'Error'} - Whispering
+		{page.status === 404 ? 'Page Not Found' : 'Error'} - Whispering
 	</title>
 </svelte:head>
 
 <main class="flex flex-1 flex-col items-center justify-center gap-6 p-8">
 	<div class="text-center space-y-6">
 		<h1 class="text-4xl font-bold text-foreground">
-			{#if $page.status === 404}
+			{#if page.status === 404}
 				404 - Page Not Found
 			{:else}
 				Something Went Wrong
@@ -19,7 +19,7 @@
 		</h1>
 
 		<p class="text-muted-foreground text-lg">
-			{#if $page.status === 404}
+			{#if page.status === 404}
 				The page you're looking for doesn't exist.
 			{:else}
 				An unexpected error occurred.


### PR DESCRIPTION
I realized that we didn't have a dedicated error page so therefore I added a very simple version of the page. 

> Before 

<img width="1250" height="504" alt="Screenshot 2025-09-07 at 7 03 47 PM" src="https://github.com/user-attachments/assets/c9f71cc8-5cd8-41e0-96e9-8e293e8775d7" />

> After
<img width="1234" height="680" alt="Screenshot 2025-09-07 at 7 03 23 PM" src="https://github.com/user-attachments/assets/0f139faa-b83c-4afe-b7bd-20ef35943681" />
