### PR TITLE
chore: remove eslint perfectionist plugin and sorting rules

### DIFF
--- a/packages/config/eslint.ts
+++ b/packages/config/eslint.ts
@@ -11,52 +11,6 @@ import js from '@eslint/js';
  * This should be included in all configurations to ensure consistent formatting.
  */
 export const base = [
-	perfectionist.configs['recommended-natural'],
-	{
-		rules: {
-			'perfectionist/sort-exports': 'off', // Only sort imports, not exports
-			'perfectionist/sort-objects': [
-				'error',
-				{
-					type: 'natural',
-					order: 'asc',
-					groups: ['children', 'title', 'description', 'cause', 'context', 'message', 'unknown'],
-					customGroups: [
-						{
-							groupName: 'children',
-							selector: 'property',
-							elementNamePattern: '^children$',
-						},
-						{
-							groupName: 'title',
-							selector: 'property',
-							elementNamePattern: '^title$',
-						},
-						{
-							groupName: 'description',
-							selector: 'property',
-							elementNamePattern: '^description$',
-						},
-						{
-							groupName: 'cause',
-							selector: 'property',
-							elementNamePattern: '^cause$',
-						},
-						{
-							groupName: 'context',
-							selector: 'property',
-							elementNamePattern: '^context$',
-						},
-						{
-							groupName: 'message',
-							selector: 'property',
-							elementNamePattern: '^message$',
-						},
-					],
-				},
-			],
-		},
-	},
 	{
 		ignores: [
 			// Build outputs


### PR DESCRIPTION
This PR removes the ESLint perfectionist plugin and its associated sorting rules from our base configuration.

The perfectionist plugin was enforcing automatic sorting of imports and objects throughout the codebase. While code organization is important, enforcing strict alphabetical/natural sorting can be counterproductive in several scenarios:

1. Semantic grouping is often more valuable than alphabetical sorting - Related imports or object properties are better kept together based on their logical relationship rather than alphabetical order. For example, grouping all UI component imports together, then utility imports, then types.
2. Unnecessary code churn - The sorting rules create noise in diffs when developers need to add new imports or properties, making PR reviews harder and git history less meaningful.
3. Conflicts with intentional ordering - Sometimes the order of exports or object properties is intentional for readability or to tell a story through the code structure.
4. Development friction - Developers spend time fighting with or working around the linter rather than focusing on actual logic.

By removing these rules, we trust developers to organize their code sensibly while reducing friction and allowing for more flexible, context-appropriate code organization.