### PR TITLE
refactor(config): remove perfectionist ESLint plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -203,7 +203,6 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "eslint-config-prettier": "^10.1.5",
-        "eslint-plugin-perfectionist": "^4.15.0",
         "eslint-plugin-svelte": "^3.10.1",
         "globals": "^16.3.0",
         "prettier": "catalog:",
@@ -1316,8 +1315,6 @@
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
-    "eslint-plugin-perfectionist": ["eslint-plugin-perfectionist@4.15.0", "", { "dependencies": { "@typescript-eslint/types": "^8.34.1", "@typescript-eslint/utils": "^8.34.1", "natural-orderby": "^5.0.0" }, "peerDependencies": { "eslint": ">=8.45.0" } }, "sha512-pC7PgoXyDnEXe14xvRUhBII8A3zRgggKqJFx2a82fjrItDs1BSI7zdZnQtM2yQvcyod6/ujmzb7ejKPx8lZTnw=="],
-
     "eslint-plugin-svelte": ["eslint-plugin-svelte@3.11.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.6.1", "@jridgewell/sourcemap-codec": "^1.5.0", "esutils": "^2.0.3", "globals": "^16.0.0", "known-css-properties": "^0.37.0", "postcss": "^8.4.49", "postcss-load-config": "^3.1.4", "postcss-safe-parser": "^7.0.0", "semver": "^7.6.3", "svelte-eslint-parser": "^1.3.0" }, "peerDependencies": { "eslint": "^8.57.1 || ^9.0.0", "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-KliWlkieHyEa65aQIkRwUFfHzT5Cn4u3BQQsu3KlkJOs7c1u7ryn84EWaOjEzilbKgttT4OfBURA8Uc4JBSQIw=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -1803,8 +1800,6 @@
     "nanostores": ["nanostores@0.11.4", "", {}, "sha512-k1oiVNN4hDK8NcNERSZLQiMfRzEGtfnvZvdBvey3SQbgn8Dcrk0h1I6vpxApjb10PFUflZrgJ2WEZyJQ+5v7YQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
-
-    "natural-orderby": ["natural-orderby@5.0.0", "", {}, "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 

--- a/packages/config/eslint.ts
+++ b/packages/config/eslint.ts
@@ -1,7 +1,6 @@
 import globals from 'globals';
 import prettier from 'eslint-config-prettier';
 import svelte from 'eslint-plugin-svelte';
-import perfectionist from 'eslint-plugin-perfectionist';
 import type { Linter } from 'eslint';
 import ts from 'typescript-eslint';
 import js from '@eslint/js';

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,7 +14,6 @@
 	"devDependencies": {
 		"@eslint/js": "^9.30.1",
 		"eslint-config-prettier": "^10.1.5",
-		"eslint-plugin-perfectionist": "^4.15.0",
 		"eslint-plugin-svelte": "^3.10.1",
 		"globals": "^16.3.0",
 		"prettier-plugin-svelte": "^3.4.0",


### PR DESCRIPTION
Remove eslint-plugin-perfectionist references from the shared ESLint
configuration and package listings. This deletes the import and
dependency entries in packages/config/eslint.ts and package.json, and
removes the corresponding entries from bun.lock (plugin, its peer
constraints, and its transitive dependency natural-orderby).

This cleans up unused/obsolete linting tooling and reduces dependency
surface area for the config package.