### PR TITLE
feat(api-keys): add deepgram APIkeyInput component in settings

### DIFF
--- a/apps/whispering/src/routes/(config)/settings/api-keys/+page.svelte
+++ b/apps/whispering/src/routes/(config)/settings/api-keys/+page.svelte
@@ -6,6 +6,7 @@
 		GroqApiKeyInput,
 		OpenAiApiKeyInput,
 		OpenRouterApiKeyInput,
+		DeepgramApiKeyInput,
 	} from '$lib/components/settings';
 	import { Separator } from '@repo/ui/separator';
 </script>
@@ -24,6 +25,7 @@
 	<Separator />
 
 	<OpenAiApiKeyInput />
+	<DeepgramApiKeyInput />
 	<OpenRouterApiKeyInput />
 	<AnthropicApiKeyInput />
 	<GroqApiKeyInput />


### PR DESCRIPTION
Adding the  `<DeepgramApiKeyInput />` in the `settings/api-keys` page since we already have code to support it. 