### PR TITLE
fix(parakeet): add inference parameters for transcription

### DIFF
--- a/apps/whispering/src-tauri/src/transcription/mod.rs
+++ b/apps/whispering/src-tauri/src/transcription/mod.rs
@@ -7,7 +7,7 @@ use transcribe_rs::{
     TranscriptionEngine,
     engines::{
         whisper::{WhisperEngine, WhisperInferenceParams},
-        parakeet::{ParakeetEngine, ParakeetModelParams},
+        parakeet::{ParakeetEngine, ParakeetModelParams, ParakeetInferenceParams, TimestampGranularity},
     },
 };
 
@@ -186,8 +186,13 @@ pub async fn transcribe_audio_parakeet(
             message: format!("Failed to load Parakeet model: {}", e)
         })?;
 
-    // Run transcription - Parakeet doesn't support language selection
-    let result = engine.transcribe_samples(samples, None)
+    let params = ParakeetInferenceParams {
+        timestamp_granularity: TimestampGranularity::Segment,
+        ..Default::default()
+    };
+
+    // Run transcription with optimized parameters
+    let result = engine.transcribe_samples(samples, Some(params))
         .map_err(|e| TranscriptionError::TranscriptionError {
             message: e.to_string(),
         })?;


### PR DESCRIPTION
This change adds proper inference parameters to the Parakeet transcription engine.

Previously, we were passing `None` for the inference parameters. This PR configures `ParakeetInferenceParams` with `TimestampGranularity::Segment` to follow recommended usage patterns and potentially improve performance.

## Changes
- Import `ParakeetInferenceParams` and `TimestampGranularity` from transcribe-rs
- Configure inference params with segment-level timestamp granularity
- Pass configured params instead of `None` to `transcribe_samples()`

## Testing
This is a minimal change that should be tested with existing Parakeet transcription workflows to verify any performance improvements.