### PR TITLE
feat(dev): add Svelte inspector in bottom-center.

### DIFF
--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -43,3 +43,12 @@
 </QueryClientProvider>
 
 <SvelteQueryDevtools client={queryClient} buttonPosition="bottom-left" />
+
+<style>
+	/* Override inspector button to bottom-center positioning */
+	:global(#svelte-inspector-host > *) {
+		left: 50% !important;
+		transform: translateX(-50%) !important;
+		right: auto !important;
+	}
+</style>

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -46,7 +46,7 @@
 
 <style>
 	/* Override inspector button to bottom-center positioning */
-	:global(#svelte-inspector-host > *) {
+	:global(#svelte-inspector-host button) {
 		bottom: 16px !important;
 		left: 50% !important;
 		transform: translateX(-50%) !important;

--- a/apps/whispering/src/routes/+layout.svelte
+++ b/apps/whispering/src/routes/+layout.svelte
@@ -47,6 +47,7 @@
 <style>
 	/* Override inspector button to bottom-center positioning */
 	:global(#svelte-inspector-host > *) {
+		bottom: 16px !important;
 		left: 50% !important;
 		transform: translateX(-50%) !important;
 		right: auto !important;

--- a/apps/whispering/svelte.config.js
+++ b/apps/whispering/svelte.config.js
@@ -17,18 +17,15 @@ const config = {
 	preprocess: vitePreprocess(),
 
 	vitePlugin: {
-		inspector:
-			process.env.NODE_ENV !== 'production'
-				? {
-						holdMode: true,
-						showToggleButton: 'always',
-						// Using 'bottom-left' as base position, but CSS overrides in
-						// src/routes/+layout.svelte move it to bottom-center to avoid
-						// conflicts with devtools (bottom-left) and toasts (bottom-right)
-						toggleButtonPos: 'bottom-left',
-						toggleKeyCombo: 'meta-shift',
-					}
-				: false,
+		inspector: {
+			holdMode: true,
+			showToggleButton: 'always',
+			// Using 'bottom-left' as base position, but CSS overrides in
+			// src/routes/+layout.svelte move it to bottom-center to avoid
+			// conflicts with devtools (bottom-left) and toasts (bottom-right)
+			toggleButtonPos: 'bottom-left',
+			toggleKeyCombo: 'meta-shift',
+		},
 	},
 };
 

--- a/apps/whispering/svelte.config.js
+++ b/apps/whispering/svelte.config.js
@@ -15,6 +15,21 @@ const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
+
+	vitePlugin: {
+		inspector:
+			process.env.NODE_ENV !== 'production'
+				? {
+						holdMode: true,
+						showToggleButton: 'always',
+						// Using 'bottom-left' as base position, but CSS overrides in
+						// src/routes/+layout.svelte move it to bottom-center to avoid
+						// conflicts with devtools (bottom-left) and toasts (bottom-right)
+						toggleButtonPos: 'bottom-left',
+						toggleKeyCombo: 'meta-shift',
+					}
+				: false,
+	},
 };
 
 export default config;


### PR DESCRIPTION
This PR adds [Svelte Inspector](https://www.npmjs.com/package/@sveltejs/vite-plugin-svelte-inspector)
- For new devs: helps discover relevant source files.
- For experienced devs: convenient way to open Svelte files in editor.
- Activated via toggle button or CMD-SHIFT/CTRL-SHIFT (+ click)

Summary of changes:
- Enable Svelte inspector for click-to-edit-source functionality
- Configure bottom-center positioning to avoid UI conflicts with devtools and toasts
- Support toggle button (always visible) and keyboard shortcuts (Cmd+Shift, Alt+X)

<img width="1082" height="802" alt="image" src="https://github.com/user-attachments/assets/5b08d1f9-764a-40ae-80e4-37e79e5522b6" />





