### PR TITLE
fix: invalidate all recordings query after creating a new recording

### DIFF
--- a/apps/whispering/src/lib/query/recordings.ts
+++ b/apps/whispering/src/lib/query/recordings.ts
@@ -57,6 +57,9 @@ export const recordings = {
 				recording,
 			);
 			queryClient.invalidateQueries({
+				queryKey: recordingKeys.all,
+			});
+			queryClient.invalidateQueries({
 				queryKey: recordingKeys.latest,
 			});
 


### PR DESCRIPTION
This fixes the issue where the recordings page doesn't update when a recording is created while already on the recordings page.

Previously, when creating a recording from the recordings page itself, the new recording wouldn't appear in the table until the page was manually refreshed or navigated away and back. The issue occurred because while the mutation updated the cache via setQueryData, it didn't invalidate the query, which is necessary to trigger re-renders for active query consumers.

This change adds queryClient.invalidateQueries for recordingKeys.all to the createRecording mutation. The mutation now follows the standard TanStack Query pattern: use setQueryData for optimistic updates (immediate UI feedback), then use invalidateQueries to mark the query as stale and trigger a background refetch. This ensures consistency and notifies all active subscribers of the cache update.