### PR TITLE
feat(linux): add explicit file system permissions for app data directory

### DIFF
--- a/apps/whispering/src-tauri/capabilities/default.json
+++ b/apps/whispering/src-tauri/capabilities/default.json
@@ -34,7 +34,10 @@
       "allow": [
         { "path": "**" },
         { "path": "$APPLOCALDATA/**" },
-        { "path": "$LOCALDATA/**" }
+        { "path": "$LOCALDATA/**" },
+        { "path": "$APPDATA/**" },
+        { "path": "$HOME/.local/share/**" },
+        { "path": "$HOME/.local/share/com.bradenwong.whispering/**" }
       ]
     },
     {


### PR DESCRIPTION
This change adds explicit Linux-specific file system paths to the Tauri capabilities configuration to resolve file access permission errors on Linux systems.

On Linux, Tauri's file system security model requires explicit permission grants for app data directories, even when wildcard permissions are configured. This was causing "forbidden path" errors when users tried to download models or save recordings.

The update adds three Linux-specific paths to the `fs:scope` permission in `capabilities/default.json`:
- `$APPDATA/**` for cross-platform app data compatibility
- `$HOME/.local/share/**` for general Linux app data directory access  
- `$HOME/.local/share/com.bradenwong.whispering/**` for explicit Whispering app directory access

This addresses file system permission issues reported by Linux users but does not fully resolve all Linux-related problems. Additional work is needed for audio device enumeration and microphone permission handling.

Related to #798, #775, #839, #670