### PR TITLE
feat(CompressionBody): add ffmpeg installation warning alert

### DIFF
--- a/apps/whispering/src/lib/components/settings/CompressionBody.svelte
+++ b/apps/whispering/src/lib/components/settings/CompressionBody.svelte
@@ -6,10 +6,12 @@
 	import { FFMPEG_DEFAULT_COMPRESSION_OPTIONS } from '$lib/services/recorder/ffmpeg';
 	import { settings } from '$lib/stores/settings.svelte';
 	import { cn } from '@repo/ui/utils';
-	import { RotateCcw } from '@lucide/svelte';
+	import { RotateCcw, AlertTriangle } from '@lucide/svelte';
 	import { isCompressionRecommended } from '../../../routes/+layout/check-ffmpeg';
 	import { createQuery } from '@tanstack/svelte-query';
 	import { rpc } from '$lib/query';
+	import * as Alert from '@repo/ui/alert';
+	import { Link } from '@repo/ui/link';
 
 	// Compression preset definitions (UI only - not stored in settings)
 	const COMPRESSION_PRESETS = {
@@ -171,5 +173,20 @@
 				output.opus
 			</code>
 		</div>
+	{/if}
+
+	<!-- FFmpeg Installation Warning -->
+	{#if !isFfmpegInstalled && !isFfmpegCheckLoading}
+		<Alert.Root variant="warning">
+			<AlertTriangle class="size-4" />
+			<Alert.Title>FFmpeg Required</Alert.Title>
+			<Alert.Description>
+				Audio compression requires FFmpeg to be installed on your system.
+				<Link href="/install-ffmpeg" class="font-medium underline underline-offset-4">
+					Install FFmpeg
+				</Link>
+				to enable this feature.
+			</Alert.Description>
+		</Alert.Root>
 	{/if}
 </div>


### PR DESCRIPTION
This change adds an amber warning alert to the compression settings that appears when FFmpeg is not installed. Previously, the compression checkbox was simply disabled without a clear explanation of why or how to enable it.

The warning alert appears at the bottom of the CompressionBody component and includes an AlertTriangle icon for visual emphasis, clear messaging that FFmpeg is required for audio compression, and a direct link to the /install-ffmpeg page for easy installation.

This alert displays in both locations where compression settings appear: the compression popover in the app header and the transcription settings page. Users now have a clear path forward when they encounter the disabled compression checkbox.